### PR TITLE
Make functions open so they can be subclasses

### DIFF
--- a/Sources/AnyURLSession/URLSession.swift
+++ b/Sources/AnyURLSession/URLSession.swift
@@ -50,27 +50,28 @@ open class URLSession: NSObject {
   public init(configuration: URLSessionConfiguration) {
     _guts = Dependencies.current.value!.gutsFactory(configuration, nil, nil)
   }
+
   public init(configuration: URLSessionConfiguration, delegate: URLSessionDelegate?, delegateQueue queue: OperationQueue?) {
     _guts = Dependencies.current.value!.gutsFactory(configuration, delegate, queue)
   }
 
-  public func uploadTask(with request: URLRequest, fromFile file: URL, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> URLSessionUploadTask {
+  open func uploadTask(with request: URLRequest, fromFile file: URL, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> URLSessionUploadTask {
     _guts.uploadTask(with: request, fromFile: file, completionHandler: completionHandler)
   }
 
-  public func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> URLSessionDataTask {
+  open func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> URLSessionDataTask {
     _guts.dataTask(with: request, completionHandler: completionHandler)
   }
 
-  public func dataTask(with request: URLRequest) -> URLSessionDataTask {
+  open func dataTask(with request: URLRequest) -> URLSessionDataTask {
     _guts.dataTask(with: request)
   }
 
-  public func invalidateAndCancel() {
+  open func invalidateAndCancel() {
     _guts.invalidateAndCancel()
   }
 
-  public func finishTasksAndInvalidate() {
+  open func finishTasksAndInvalidate() {
     _guts.finishTasksAndInvalidate()
   }
 }

--- a/Sources/AnyURLSession/URLSessionTask.swift
+++ b/Sources/AnyURLSession/URLSessionTask.swift
@@ -5,8 +5,8 @@ import class Foundation.NSObject
 // https://github.com/apple/swift-corelibs-foundation/blob/main/Sources/FoundationNetworking/URLSession/URLSessionTask.swift\
 open class URLSessionTask: NSObject {
   open var state: URLSessionTask.State = .suspended
-  public func resume() {}
-  public func cancel() {}
+  open func resume() {}
+  open func cancel() {}
 }
 
 extension URLSessionTask {

--- a/Tests/AnyURLSessionTests/Helpers/Mocks.swift
+++ b/Tests/AnyURLSessionTests/Helpers/Mocks.swift
@@ -5,7 +5,17 @@ import class FoundationNetworking.URLSessionConfiguration
 import class FoundationNetworking.URLResponse
 import struct FoundationNetworking.URLRequest
 
-@testable import AnyURLSession
+import AnyURLSession
+
+final class MockGutsSessionTask: URLSessionTask {
+  override func resume() {
+    // Do nothing, but make sure we can override this
+  }
+
+  override func cancel() {
+    // Do nothing, but make sure we can override this
+  }
+}
 
 final class MockGuts: URLSessionGuts {
   var configuration: URLSessionConfiguration


### PR DESCRIPTION
When trying to implement a custom `URLSessionTask` I ran into the compiler error that they were not `open` so we could override them or provide our own implementation.

Taking more notes from the `swift-corelibs-foundation` repo, it seems that most of these functions should be `open` so that they could be subclassed if needed.