### PR TITLE
Mark URLSessionDelegate protocol as Sendable

### DIFF
--- a/Sources/AnyURLSession/URLSession.swift
+++ b/Sources/AnyURLSession/URLSession.swift
@@ -83,7 +83,7 @@ open class URLSession: NSObject {
   }
 }
 
-public protocol URLSessionDelegate: NSObjectProtocol {
+public protocol URLSessionDelegate: NSObjectProtocol, Sendable {
   func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?)
   func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
 }


### PR DESCRIPTION
This is consistent with Apple's documentation:
https://developer.apple.com/documentation/foundation/urlsessiondelegate