### PR TITLE
Android support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,10 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
       - name: Run tests
         run: swift test
+
+  library-android:
+    name: Android - Swift 6.0 - SPM
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: skiptools/swift-android-action@v2

--- a/Sources/AnyURLSession/Dependencies.swift
+++ b/Sources/AnyURLSession/Dependencies.swift
@@ -1,4 +1,4 @@
-#if os(Linux) || os(Windows)
+#if os(Linux) || os(Windows) || os(Android)
 import class Foundation.OperationQueue
 import class FoundationNetworking.URLSessionConfiguration
 

--- a/Sources/AnyURLSession/Exports.swift
+++ b/Sources/AnyURLSession/Exports.swift
@@ -1,4 +1,4 @@
-#if os(Linux) || os(Windows)
+#if os(Linux) || os(Windows) || os(Android)
 // Automatically export the imports that people will most likely require when
 // using the AnyURLSession library in their project.
 @_exported import class FoundationNetworking.HTTPURLResponse

--- a/Sources/AnyURLSession/LockIsolated.swift
+++ b/Sources/AnyURLSession/LockIsolated.swift
@@ -1,4 +1,4 @@
-#if os(Linux) || os(Windows)
+#if os(Linux) || os(Windows) || os(Android)
 import class Foundation.NSRecursiveLock
 
 // A lightweight copy/rebuild of the LockIsolated class from Concurrency Extras

--- a/Sources/AnyURLSession/URLSession.swift
+++ b/Sources/AnyURLSession/URLSession.swift
@@ -1,4 +1,4 @@
-#if os(Linux) || os(Windows)
+#if os(Linux) || os(Windows) || os(Android)
 import class FoundationNetworking.CachedURLResponse
 import class FoundationNetworking.HTTPURLResponse
 import class FoundationNetworking.URLAuthenticationChallenge

--- a/Sources/AnyURLSession/URLSessionGuts.swift
+++ b/Sources/AnyURLSession/URLSessionGuts.swift
@@ -1,4 +1,4 @@
-#if os(Linux) || os(Windows)
+#if os(Linux) || os(Windows) || os(Android)
 import Foundation
 
 import class FoundationNetworking.URLSessionConfiguration

--- a/Sources/AnyURLSession/URLSessionTask.swift
+++ b/Sources/AnyURLSession/URLSessionTask.swift
@@ -1,4 +1,4 @@
-#if os(Linux) || os(Windows)
+#if os(Linux) || os(Windows) || os(Android)
 import class Foundation.NSObject
 
 // Reimplemented interfaces for URLSession that will allow for stubbing/subclassing

--- a/Tests/AnyURLSessionTests/CrossPlatformCompatibilityTests.swift
+++ b/Tests/AnyURLSessionTests/CrossPlatformCompatibilityTests.swift
@@ -8,7 +8,7 @@ import FoundationNetworking
 
 final class CrossPlatformCompatibilityTests: XCTestCase {
   func testForcedToSpecifyModuleToDisambiguate() async {
-    #if os(Linux) || os(Windows)
+    #if os(Linux) || os(Windows) || os(Android)
     _ = FoundationNetworking.URLSession(configuration: .default)
 
     await withDependencies({

--- a/Tests/AnyURLSessionTests/Helpers/Mocks.swift
+++ b/Tests/AnyURLSessionTests/Helpers/Mocks.swift
@@ -1,4 +1,4 @@
-#if os(Linux) || os(Windows)
+#if os(Linux) || os(Windows) || os(Android)
 import Foundation
 
 import class FoundationNetworking.URLSessionConfiguration

--- a/Tests/AnyURLSessionTests/NonDarwinCompatibilityTests.swift
+++ b/Tests/AnyURLSessionTests/NonDarwinCompatibilityTests.swift
@@ -1,4 +1,4 @@
-#if os(Windows) || os(Linux)
+#if os(Windows) || os(Linux) || os(Android)
 import Foundation
 import XCTest
 @testable import AnyURLSession


### PR DESCRIPTION
This PR adds support for Android, as well as a CI job that builds and run the tests against an Android emulator using the [swift-android-action](https://github.com/marketplace/actions/swift-android-action).